### PR TITLE
Added a $watch to the first item in safeSrc

### DIFF
--- a/src/stTable.js
+++ b/src/stTable.js
@@ -48,6 +48,17 @@ ng.module('smart-table')
 
     if ($attrs.stSafeSrc) {
       safeGetter = $parse($attrs.stSafeSrc);
+      $scope.$watch(function() {
+        var safeSrc = safeGetter($scope);
+        if (safeSrc && safeSrc.length !== undefined && safeSrc.length > 0) {
+          return safeSrc[0];
+        }
+        return undefined;
+      }, function(newValue, oldValue) {
+        if (newValue !== oldValue) {
+          updateSafeCopy();
+        }
+      });
       $scope.$watch(function () {
         var safeSrc = safeGetter($scope);
         return safeSrc ? safeSrc.length : 0;


### PR DESCRIPTION
Added a `$watch` to the first item in the `stSafeSrc` array. This change `$watch`'s the first element of the `stSafeSrc` if it exists and updates the `stTable` accordingly.

Although #205 addresses a similar issue it doesn't address the case of many similar length arrays being swapped out of an instance of `stTable`.
